### PR TITLE
Changed image tag naming

### DIFF
--- a/dist/bratiska-cli.js
+++ b/dist/bratiska-cli.js
@@ -38,7 +38,7 @@ const tag_1 = require("./tag");
 const label_1 = require("./label");
 const common_1 = require("./common");
 const helpers = __importStar(require("./helpers"));
-const version = "3.5.0";
+const version = "3.5.1";
 const deploy = new deploy_1.Deploy();
 const tag = new tag_1.Tag();
 const common = new common_1.Common();
@@ -47,13 +47,13 @@ const build_kustomize = new build_kustomize_1.BuildKustomize();
 const label = new label_1.Label();
 try {
     (0, clear_1.default)();
-    console.log(chalk_1.default.blue(figlet_1.default.textSync("Bratiska-cli", { horizontalLayout: "full" })));
+  console.log(chalk_1.default.blue(figlet_1.default.textSync("Bratiska-cli", { horizontalLayout: "full" })));
     commander_1.program
       .name("bratiska-cli")
       .version(version)
       .description("Simple Bratiska-cli utility for managing Bratislava Innovation apps")
       .action(() => {
-          console.log(chalk_1.default.green("Please choose from selected commands based on yur needs. My favourite command is `deploy`."));
+        console.log(chalk_1.default.green("Please choose from selected commands based on yur needs. My favourite command is `deploy`."));
         commander_1.program.help();
     });
     commander_1.program
@@ -232,7 +232,7 @@ try {
         /* step 1 */
         build_image.check_build_image_commands(options);
         /* step 2 */
-          common.show_options("build_image", options);
+        common.show_options("build_image", options);
         /* step 3 */
         common.get_git_current_branch(options);
         /* step 4 */
@@ -354,7 +354,7 @@ try {
         /* step 1 */
         label.check_label_commands(options);
         /* step 2 */
-          common.show_options("", options);
+        common.show_options("", options);
         /* step 3 */
         label.show_label_info(label_value, options);
         /* step 4 */
@@ -377,6 +377,6 @@ try {
     // @ts-ignore
 }
 catch (e) {
-    helpers.log("\x1b[31m", `\nISSUE: ${e.message}`);
+  helpers.log("\x1b[31m", `\nISSUE: ${e.message}`);
     process.exit(1);
 }

--- a/dist/common/show_options.js
+++ b/dist/common/show_options.js
@@ -37,6 +37,7 @@ const path = __importStar(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const crypto_1 = __importDefault(require("crypto"));
 function show_options(env, options) {
+  options.timestamp = Date.now();
   if (typeof env !== "undefined" &&
     env !== "" &&
     typeof options.env === "undefined") {

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -181,7 +181,8 @@ function tag(options) {
   let untracked = "";
   let pipelines = "";
   let commit = "";
-  let tag = "";
+  let timestamp = "";
+  let env = "";
   let branch = "-" + options.branch;
     if (options.untracked) {
       untracked = "-untracked";
@@ -192,6 +193,9 @@ function tag(options) {
     if (options.commit) {
         commit = `-${options.commit}`;
     }
+  if (options.timestamp) {
+    timestamp = `-${options.timestamp}`;
+  }
   let force_rebuild = "";
     if (options.force_rebuild) {
       force_rebuild = "-force-rebuild-" + crypto_1.default.randomBytes(20).toString("hex");
@@ -199,10 +203,10 @@ function tag(options) {
     if (options.pipelines) {
       pipelines = "-pipelines";
     }
-    if (options.gittag) {
-        tag = `-tag-${options.gittag}`;
+  if (options.env) {
+    env = `-${options.env}`;
     }
-    let tag_value = `bratiska-cli-v${options.bratiska_cli_version}${pipelines}${untracked}${force_rebuild}${branch}${commit}${tag}-v${options.version}`;
+  let tag_value = `bratiska-cli-v${options.bratiska_cli_version}${pipelines}${untracked}${force_rebuild}${branch}${commit}${env}${timestamp}`;
   tag_value = tag_value.replace(" ", "-");
   tag_value = tag_value.replace("+", "-");
   tag_value = tag_value.replace(/[#@/\\_]/g, "-");
@@ -431,6 +435,7 @@ function load_package(options) {
         throw new Error("There was an issue getting the current working directory!");
         }
         options = {
+          timestamp: Date.now(),
           app_port: "",
           cluster: "",
           commit: "",
@@ -529,6 +534,9 @@ function print_options(options) {
     if (options.recursive) {
         print_important_info_spacer(`--recursive`);
     }
+  if (options.timestamp) {
+    print_important_info_spacer(`--timestamp=${options.timestamp}`);
+  }
     if (options.env) {
         print_important_info_spacer(`--env=${options.env}`);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bratiska-cli",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Simple CLI for deploying Bratislava apps to kubernetes",
   "preferGlobal": true,
   "bin": "./dist/bratiska-cli.js",

--- a/src/bratiska-cli.ts
+++ b/src/bratiska-cli.ts
@@ -12,7 +12,7 @@ import { Label } from './label';
 import { Common } from './common';
 import * as helpers from './helpers';
 
-const version = '3.5.0';
+const version = '3.5.1';
 const deploy = new Deploy();
 const tag = new Tag();
 const common = new Common();

--- a/src/common/show_options.ts
+++ b/src/common/show_options.ts
@@ -6,6 +6,8 @@ import crypto from 'crypto';
 import { Options } from '../types';
 
 export function show_options(env: string, options: Options) {
+  options.timestamp = Date.now();
+
   if (
     typeof env !== 'undefined' &&
     env !== '' &&

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -168,7 +168,8 @@ export function tag(options: Options) {
   let untracked = '';
   let pipelines = '';
   let commit = '';
-  let tag = '';
+  let timestamp = '';
+  let env = '';
   let branch = '-' + options.branch;
   if (options.untracked) {
     untracked = '-untracked';
@@ -181,6 +182,10 @@ export function tag(options: Options) {
     commit = `-${options.commit}`;
   }
 
+  if (options.timestamp) {
+    timestamp = `-${options.timestamp}`;
+  }
+
   let force_rebuild = '';
   if (options.force_rebuild) {
     force_rebuild = '-force-rebuild-' + crypto.randomBytes(20).toString('hex');
@@ -190,11 +195,11 @@ export function tag(options: Options) {
     pipelines = '-pipelines';
   }
 
-  if (options.gittag) {
-    tag = `-tag-${options.gittag}`;
+  if (options.env) {
+    env = `-${options.env}`;
   }
 
-  let tag_value = `bratiska-cli-v${options.bratiska_cli_version}${pipelines}${untracked}${force_rebuild}${branch}${commit}${tag}-v${options.version}`;
+  let tag_value = `bratiska-cli-v${options.bratiska_cli_version}${pipelines}${untracked}${force_rebuild}${branch}${commit}${env}${timestamp}`;
   tag_value = tag_value.replace(' ', '-');
   tag_value = tag_value.replace('+', '-');
   tag_value = tag_value.replace(/[#@/\\_]/g, '-');
@@ -474,6 +479,7 @@ export function load_package(options?: Options) {
       );
     }
     options = {
+      timestamp: Date.now(),
       app_port: '',
       cluster: '',
       commit: '',
@@ -593,6 +599,10 @@ export function print_options(options: Options) {
 
   if (options.recursive) {
     print_important_info_spacer(`--recursive`);
+  }
+
+  if (options.timestamp) {
+    print_important_info_spacer(`--timestamp=${options.timestamp}`);
   }
 
   if (options.env) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 //type Options = Record<string, string | number | boolean>;
 export interface Options
   extends Record<string, string | number | boolean | string[]> {
+  timestamp: number;
   cluster: string;
   repository_uri: string;
   deployment: string;


### PR DESCRIPTION
version 3.5.1 changed image tag naming:
- git tag is removed
- removed app version (from `package.json`) as it was not used
- added environment (`dev`, `staging`, `prod`)
- added utc timestamp at the end of image name